### PR TITLE
Add generic GraphQLResponse class to simplify constructing the response

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,29 +73,16 @@ and provide methods for accessing the field data with it already coerced to the
 correct type.
 
 ```swift
-guard let responseObj = try? JSONSerialization.jsonObject(with: responseData, options: JSONSerialization.ReadingOptions(rawValue: 0)) else {
-    print("Invalid JSON in GraphQL response")
-    return
-}
-var errors = nil
-var data = nil
-if let responseDict = responseObj as? [String: AnyObject] {
-    if let responseDict = responseObj as? [String: AnyObject] {
-        errors = responseDict?["errors"] as? [[String: AnyObject]]
-        data = responseDict?["data"] as? [String: AnyObject]
-    }
-}
-if graphData == nil && graphErrors == nil {
+guard let response = try? GraphQLResponse<ExampleSchema.QueryRoot>(jsonData: response) else {
     print("Invalid GraphQL response")
     return
 }
-if let errors = errors {
+if let errors = response.errors {
     for error in errors {
-        message = error["message"] as? String ?? "Unknown error"
-        print("GraphQL error: \(message)")
+        print("GraphQL error: \(error.message)")
     }
 }
-if let data = data {
+if let data = response.data {
     let user = data.user
     print("\(user.firstName) \(user.lastName)")
 }

--- a/support/Tests/GraphQLSupportTests/GraphQLSupportTests.swift
+++ b/support/Tests/GraphQLSupportTests/GraphQLSupportTests.swift
@@ -6,4 +6,34 @@ class GraphQLSupportTests: XCTestCase {
         let escaped = GraphQL.quoteString(input: "\0 \r \n \\ \" c ꝏ")
         XCTAssertEqual(escaped, "\"\\u0000 \\r \\n \\\\ \\\" c ꝏ\"")
     }
+
+    func testGraphQLResponseInvalidJson() {
+        let jsonData = "{".data(using: String.Encoding.utf8)!
+        do {
+            let _ = try GraphQLResponse<GraphQL.AbstractResponse>(jsonData: jsonData)
+            XCTFail("no exception thrown for invalid response")
+        } catch {
+            XCTAssertTrue(error is GraphQL.JsonParsingError)
+        }
+    }
+
+    func testInvalidResponses() {
+        let invalidJsonStrings = [
+            "[]",
+            "{}",
+            "{ \"data\": \"invalid\" }",
+            "{ \"errors\": \"invalid\" }",
+            "{ \"errors\": [{}] }",
+        ]
+        for jsonString in invalidJsonStrings {
+            let jsonData = jsonString.data(using: String.Encoding.utf8)!
+            do {
+                let _ = try GraphQLResponse<GraphQL.AbstractResponse>(jsonData: jsonData)
+                XCTFail("no exception thrown for invalid response")
+            } catch {
+                XCTAssertTrue(error is GraphQL.ViolationError)
+            }
+        }
+
+    }
 }

--- a/support/Tests/GraphQLSupportTests/IntegrationTests.swift
+++ b/support/Tests/GraphQLSupportTests/IntegrationTests.swift
@@ -61,53 +61,55 @@ class IntegrationTests: XCTestCase {
     }
 
     func testStringFieldResponse() {
-        let response = try! Generated.QueryRoot(fields: parse(json: "{\"data\":{\"version\":\"1.2.3\"}}"))
-        XCTAssertEqual(response.version, "1.2.3")
+        let data = queryData(json: "{\"data\":{\"version\":\"1.2.3\"}}")
+        XCTAssertEqual(data.version, "1.2.3")
     }
 
     func testStringListResponse() {
-        let response = try! Generated.QueryRoot(fields: parse(json: "{\"data\":{\"keys\":[\"one\", \"two\"]}}"))
-        XCTAssertEqual(response.keys, ["one", "two"])
+        let data = queryData(json: "{\"data\":{\"keys\":[\"one\", \"two\"]}}")
+        XCTAssertEqual(data.keys, ["one", "two"])
     }
 
     func testEnumFieldResponse() {
-        let response = try! Generated.QueryRoot(fields: parse(json: "{\"data\":{\"type\":\"STRING\"}}"))
-        XCTAssertEqual(response.type, .string)
+        let data = queryData(json: "{\"data\":{\"type\":\"STRING\"}}")
+        XCTAssertEqual(data.type, .string)
     }
 
     func testUnknownEnumResponse() {
-        let response = try! Generated.QueryRoot(fields: parse(json: "{\"data\":{\"type\":\"FUTURE\"}}"))
-        XCTAssertEqual(response.type, .unknownValue)
+        let data = queryData(json: "{\"data\":{\"type\":\"FUTURE\"}}")
+        XCTAssertEqual(data.type, .unknownValue)
     }
 
     func testScalarFieldResponse() {
-        let response = try! Generated.QueryRoot(fields: parse(json: "{\"data\":{\"ttl\":\"2017-01-31T10:09:48Z\"}}"))
-        XCTAssertEqual(response.ttl, date(year: 2017, month: 1, day: 31, hour: 10, minute: 9, second: 48))
+        let data = queryData(json: "{\"data\":{\"ttl\":\"2017-01-31T10:09:48Z\"}}")
+        XCTAssertEqual(data.ttl, date(year: 2017, month: 1, day: 31, hour: 10, minute: 9, second: 48))
     }
 
     func testInterfaceResponse() {
-        let response = try! Generated.QueryRoot(fields: parse(json: "{\"data\":{\"entry\":{\"__typename\":\"IntegerEntry\",\"value\":42}}}"))
-        let entry = response.entry!
+        let data = queryData(json: "{\"data\":{\"entry\":{\"__typename\":\"IntegerEntry\",\"value\":42}}}")
+        let entry = data.entry!
         XCTAssertEqual(entry.typeName, "IntegerEntry")
         let intEntry = entry as! Generated.IntegerEntry
         XCTAssertEqual(intEntry.value, 42)
     }
 
     func testInterfaceUnknownTypeResponse() {
-        let response = try! Generated.QueryRoot(fields: parse(json: "{\"data\":{\"entry\":{\"__typename\":\"FutureEntry\",\"key\":\"foo\"}}}"))
-        let entry = response.entry!
+        let data = queryData(json: "{\"data\":{\"entry\":{\"__typename\":\"FutureEntry\",\"key\":\"foo\"}}}")
+        let entry = data.entry!
         XCTAssertEqual(entry.typeName, "FutureEntry")
         XCTAssertEqual(entry.key, "foo")
     }
 
     func testMutationResponse() {
-        let response = try! Generated.Mutation(fields: parse(json: "{\"data\":{\"set_string\":true}}"))
-        XCTAssertEqual(response.setString, true)
+        let json = "{\"data\":{\"set_string\":true}}"
+        let data = try! GraphQLResponse<Generated.Mutation>(jsonData: json.data(using: String.Encoding.utf8)!).data!
+        XCTAssertEqual(data.setString, true)
     }
 
-    private func parse(json: String) -> [String: AnyObject] {
-        let responseObj = try! JSONSerialization.jsonObject(with: json.data(using: String.Encoding.utf8)!, options: JSONSerialization.ReadingOptions(rawValue: 0))
-        return (responseObj as! [String: AnyObject])["data"] as! [String: AnyObject]
+    private func queryData(json: String) -> Generated.QueryRoot {
+        let jsonData = json.data(using: String.Encoding.utf8)!
+        let response = try! GraphQLResponse<Generated.QueryRoot>(jsonData: jsonData)
+        return response.data!
     }
 
     private func date(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int) -> Date {


### PR DESCRIPTION
## Problem

I noticed that the GraphQL.swift support code didn't contain code for the top-level GraphQL response, making it awkward to check using the JSON deserialized object, as seen in the initial version of the README.

The usage should be comparable in convenience to https://github.com/shopify/graphql_java_gen

## Solution

I created a generic GraphQLResponse class that will parse the top-level response object along  with the data entry if it is present.  I also included a convenience initializer for parsing json, the most common encoding.

Note that swift didn't allow me to define a generic class nested in another class, so I wasn't able to name the class GraphQL.Response.