### PR TITLE
Add list type in case that the object is a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The generated code includes a query builder that can be used to
 create a GraphQL query in a type-safe mannar.
 
 ```swift
-let queryString = ExampleSchema.buildQuerya { $0
+let queryString = ExampleSchema.buildQuery { $0
     .user { $0
         .firstName()
         .lastName()

--- a/codegen/lib/graphql_swift_gen.rb
+++ b/codegen/lib/graphql_swift_gen.rb
@@ -206,8 +206,11 @@ class GraphQLSwiftGen
     when 'SCALAR'
       scalars[type.name].deserialize_expr(expr)
     when 'LIST'
-      rethrow = "try " if %w(OBJECT INTERFACE UNION).include?(type.unwrap.kind)
-      "#{rethrow}#{expr}.map { #{deserialize_value_code(field_name, '$0', type.of_type, untyped: !type.of_type.non_null?)} }"
+      untyped = !type.of_type.non_null?
+      rethrow = "try " if %w(OBJECT INTERFACE UNION).include?(type.unwrap.kind) || untyped
+      sub_statements = "#{rethrow}#{expr}.map { #{deserialize_value_code(field_name, '$0', type.of_type, untyped: untyped)} }"
+      sub_statements += " as [Any?]" if untyped
+      sub_statements
     when 'OBJECT'
       "try #{type.name}(fields: #{expr})"
     when 'INTERFACE', 'UNION'

--- a/codegen/test/support/schema.rb
+++ b/codegen/test/support/schema.rb
@@ -47,6 +47,9 @@ module Support
         deprecation_reason "Ambiguous, use string instead"
         argument :key, !types.String
       end
+      field :mget, !types[types.String] do
+        argument :keys, !types[!types.String]
+      end
       field :string, types.String do
         description "Get a string value with the given key"
         argument :key, !types.String

--- a/support/Tests/GraphQLSupportTests/IntegrationTests.swift
+++ b/support/Tests/GraphQLSupportTests/IntegrationTests.swift
@@ -17,6 +17,11 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(String(describing: query), "{keys(first:10,after:\"cursor\")}")
     }
 
+    func testArrayArgQuery() {
+        let query = Generated.buildQuery { $0.mget(keys: ["one", "two"]) }
+        XCTAssertEqual(String(describing: query), "{mget(keys:[\"one\",\"two\"])}")
+    }
+
     func testInterfaceQuery() {
         let query = Generated.buildQuery { $0
             .entry(key: "user:1") { $0
@@ -63,6 +68,12 @@ class IntegrationTests: XCTestCase {
     func testStringFieldResponse() {
         let data = queryData(json: "{\"data\":{\"version\":\"1.2.3\"}}")
         XCTAssertEqual(data.version, "1.2.3")
+    }
+
+    func testOptionalArrayResponse() {
+        let data = queryData(json: "{\"data\":{\"mget\":[\"one\", null]}}")
+        XCTAssertEqual(data.mget[0], "one")
+        XCTAssertNil(data.mget[1])
     }
 
     func testStringListResponse() {


### PR DESCRIPTION
Deserializing value code:   When the type is a list of optional values it should be followed by "?".

This PR wraps the optional value with a "?" in case the type is a list of optionals.

E.G: 

## Before
```
case "users":
	guard let value = value as? [Any] else {
		throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
	}
	return try value.map { if $0 is NSNull { return nil }
	guard let value = $0 as? [String: Any] else {
		throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
	}
	return try UnknownNode.create(fields: value) }
```

## After
```
case "users":
	guard let value = value as? [Any] else {
		throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
	}
	return try value.map { if $0 is NSNull { return nil }
	guard let value = $0 as? [String: Any] else {
		throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
	}
	return try UnknownNode.create(fields: value) } as [Any?]
```
Not that the as `[Any?]` was added 
