### PR TITLE
Make explicit NULL easy – and break less API

### DIFF
--- a/codegen/lib/graphql_swift_gen/templates/type.swift.erb
+++ b/codegen/lib/graphql_swift_gen/templates/type.swift.erb
@@ -231,12 +231,12 @@ extension <%= schema_name %> {
       public init(
         <% input_fields = type.required_input_fields + type.optional_input_fields # manually ordered with required fields first %>
         <% input_fields.each do |field| %>
-          <% seperator = field == input_fields.last ? "" : "," %>
+          <% separator = field == input_fields.last ? "" : "," %>
           <% if field.type.non_null? %>
-            <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type, non_null: true) %><%= seperator %>
+            <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type, non_null: true) %><%= separator %>
           <% else %>
             <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type) %> = nil,
-            serialize<%= escape_reserved_word(field.classify_name) %>: Bool = false<%= seperator %>
+            serialize<%= escape_reserved_word(field.classify_name) %>: Bool = false<%= separator %>
           <% end %>
         <% end %>
       ) {

--- a/codegen/lib/graphql_swift_gen/templates/type.swift.erb
+++ b/codegen/lib/graphql_swift_gen/templates/type.swift.erb
@@ -221,20 +221,11 @@ extension <%= schema_name %> {
 
         open var <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type) %> {
           didSet {
-            <%= escape_reserved_word(field.camelize_name) %>Seen = true
+            serialize<%= escape_reserved_word(field.classify_name) %> = true
           }
         }
-
-        // Observes if the <%= escape_reserved_word(field.camelize_name) %> property was set.
-        private var <%= escape_reserved_word(field.camelize_name) %>Seen: Bool = false
-
-        // Unsets the <%= escape_reserved_word(field.camelize_name) %> property so that it is not serialized.
-        @discardableresult
-        open func unset<%= escape_reserved_word(field.classify_name) %>() -> <%= type.name %> {
-          <%= escape_reserved_word(field.camelize_name) %> = nil
-          <%= escape_reserved_word(field.camelize_name) %>Seen = false
-          return self
-        }
+        // Observes if the <%= escape_reserved_word(field.camelize_name) %> property was set, and indicates whether it should be serialized.
+        open var serialize<%= escape_reserved_word(field.classify_name) %>: Bool
       <% end %>
 
       public init(
@@ -244,7 +235,8 @@ extension <%= schema_name %> {
           <% if field.type.non_null? %>
             <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type, non_null: true) %><%= seperator %>
           <% else %>
-            <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type) %> = nil<%= seperator %>
+            <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type) %> = nil,
+            serialize<%= escape_reserved_word(field.classify_name) %>: Bool = false<%= seperator %>
           <% end %>
         <% end %>
       ) {
@@ -252,10 +244,11 @@ extension <%= schema_name %> {
           self.<%= escape_reserved_word(field.camelize_name) %> = <%= escape_reserved_word(field.camelize_name) %>
         <% end %>
         <% type.optional_input_fields.each do |field| %>
+          self.serialize<%= escape_reserved_word(field.classify_name) %> = serialize<%= escape_reserved_word(field.classify_name) %>
           <% field_name = escape_reserved_word(field.camelize_name) %>
           if let <%= field_name %> = <%= field_name %> {
-            self.<%= field_name %>Seen = true
             self.<%= field_name %> = <%= field_name %>
+            self.serialize<%= escape_reserved_word(field.classify_name) %> = true
           }
         <% end %>
       }
@@ -266,7 +259,7 @@ extension <%= schema_name %> {
           fields.append("<%= field.name %>:<%= generate_build_input_code(field.camelize_name, field.type.unwrap_non_null) %>")
         <% end %>
         <% type.optional_input_fields.each do |field| %>
-          if <%= escape_reserved_word(field.camelize_name) %>Seen {
+          if serialize<%= escape_reserved_word(field.classify_name) %> {
             if let <%= escape_reserved_word(field.camelize_name) %> = <%= escape_reserved_word(field.camelize_name) %> {
               fields.append("<%= field.name %>:<%= generate_build_input_code(field.camelize_name, field.type.unwrap_non_null) %>")
             } else {

--- a/codegen/lib/graphql_swift_gen/templates/type.swift.erb
+++ b/codegen/lib/graphql_swift_gen/templates/type.swift.erb
@@ -214,15 +214,27 @@ extension <%= schema_name %> {
   <% when 'INPUT_OBJECT' %>
     open class <%= type.name %> {
       <% type.required_input_fields.each do |field| %>
-       open var <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type) %>
+
+       open var <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type, non_null: true) %>
       <% end %>
       <% type.optional_input_fields.each do |field| %>
+
         open var <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type) %> {
           didSet {
             <%= escape_reserved_word(field.camelize_name) %>Seen = true
           }
         }
+
+        // Observes if the <%= escape_reserved_word(field.camelize_name) %> property was set.
         private var <%= escape_reserved_word(field.camelize_name) %>Seen: Bool = false
+
+        // Unsets the <%= escape_reserved_word(field.camelize_name) %> property so that it is not serialized.
+        @discardableresult
+        open func unset<%= escape_reserved_word(field.classify_name) %>() -> <%= type.name %> {
+          <%= escape_reserved_word(field.camelize_name) %> = nil
+          <%= escape_reserved_word(field.camelize_name) %>Seen = false
+          return self
+        }
       <% end %>
 
       public init(
@@ -230,9 +242,9 @@ extension <%= schema_name %> {
         <% input_fields.each do |field| %>
           <% seperator = field == input_fields.last ? "" : "," %>
           <% if field.type.non_null? %>
-            <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type) %><%= seperator %>
+            <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type, non_null: true) %><%= seperator %>
           <% else %>
-            <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type) %>? = nil<%= seperator %>
+            <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type) %> = nil<%= seperator %>
           <% end %>
         <% end %>
       ) {

--- a/support/Tests/GraphQLSupportTests/IntegrationTests.swift
+++ b/support/Tests/GraphQLSupportTests/IntegrationTests.swift
@@ -70,10 +70,10 @@ class IntegrationTests: XCTestCase {
 
     func testInputObjectExplictNilConstructor() {
         let query = Generated.buildMutation { $0
-            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: .some(nil)))
+            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: nil))
         }
         let queryString = String(describing: query)
-        XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42,negate:null})}")
+        XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42})}")
     }
 
     func testInputObjectExplictNilSetLater() {

--- a/support/Tests/GraphQLSupportTests/IntegrationTests.swift
+++ b/support/Tests/GraphQLSupportTests/IntegrationTests.swift
@@ -68,12 +68,20 @@ class IntegrationTests: XCTestCase {
         XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42,negate:true})}")
     }
 
-    func testInputObjectExplictNilConstructor() {
+    func testInputObjectOptionalFieldNilConstructor() {
         let query = Generated.buildMutation { $0
             .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: nil))
         }
         let queryString = String(describing: query)
         XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42})}")
+    }
+
+    func testInputObjectOptionalFieldExplictNilConstructor() {
+        let query = Generated.buildMutation { $0
+            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: nil, serializeNegate: true))
+        }
+        let queryString = String(describing: query)
+        XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42,negate:null})}")
     }
 
     func testInputObjectExplictNilSetLater() {


### PR DESCRIPTION
# This PR
The mirror of https://github.com/Shopify/graphql_java_gen/pull/29
~~In this PR I am adding a way to unset properties so that they aren't serialized. This change is required because currently there is no way to tell a property to not serialize. 
This is aimed to help consumers of this generator that were effected by the change #8 that used to reset their input types with `inputType.property = null` so that they can use `inputType.unsetProperty()` instead.~~

This PR has pivoted to be about making #8 cause less API breakage.


* ~~adds a public `unset{property name}` method~~
* makes required properties required non optional arguments in the init

The new input type looks like this 
```swift
class SomeClass {

  // required
  var id: Int

  // nullable
  var negate: Bool? {
    didSet {
      serailzeNegate = true
    }
  }

  var serialzeNegate: Bool

  init(
    id: int,
    negate: Bool? = nil
    serialzieNegate: Bool = false) {

    self.id = id

    self.serializeNegate = serailizeNegate
    if let negate = negate {
      self.negate = negate
      self.serializeNegate = true
    }
  }
  ...

```

- [x] Added tests
- [x] Minimize API breakage