### PR TITLE
Explicit nulls on input types using InputValue wrapper

### DIFF
--- a/codegen/lib/graphql_swift_gen/templates/type.swift.erb
+++ b/codegen/lib/graphql_swift_gen/templates/type.swift.erb
@@ -217,7 +217,7 @@ extension <%= schema_name %> {
        open var <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type, non_null: true) %>
       <% end %>
       <% type.optional_input_fields.each do |field| %>
-        open var <%= escape_reserved_word(field.camelize_name) %>: InputValue<<%= swift_input_type(field.type, non_null: true) %>>
+        open var <%= escape_reserved_word(field.camelize_name) %>: Input<<%= swift_input_type(field.type, non_null: true) %>>
       <% end %>
 
       public init(
@@ -227,7 +227,7 @@ extension <%= schema_name %> {
           <% if field.type.non_null? %>
             <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type, non_null: true) %><%= seperator %>
           <% else %>
-            <%= escape_reserved_word(field.camelize_name) %>: InputValue<<%= swift_input_type(field.type, non_null: true) %>> = .undefined<%= seperator %>
+            <%= escape_reserved_word(field.camelize_name) %>: Input<<%= swift_input_type(field.type, non_null: true) %>> = .undefined<%= seperator %>
           <% end %>
         <% end %>
       ) {
@@ -243,7 +243,7 @@ extension <%= schema_name %> {
         <% end %>
         <% type.optional_input_fields.each do |field| %>
           switch <%= escape_reserved_word(field.camelize_name) %> {
-          case .defined(let <%= escape_reserved_word(field.camelize_name) %>):
+          case .value(let <%= escape_reserved_word(field.camelize_name) %>):
             if let <%= escape_reserved_word(field.camelize_name) %> = <%= escape_reserved_word(field.camelize_name) %> {
               fields.append("<%= field.name %>:<%= generate_build_input_code(field.camelize_name, field.type.unwrap_non_null) %>")
             } else {

--- a/codegen/lib/graphql_swift_gen/templates/type.swift.erb
+++ b/codegen/lib/graphql_swift_gen/templates/type.swift.erb
@@ -213,16 +213,22 @@ extension <%= schema_name %> {
     }
   <% when 'INPUT_OBJECT' %>
     open class <%= type.name %> {
-      <% type.input_fields.each do |field| %>
-       open var <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type) %>
+      <% type.required_input_fields.each do |field| %>
+       open var <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type, non_null: true) %>
+      <% end %>
+      <% type.optional_input_fields.each do |field| %>
+        open var <%= escape_reserved_word(field.camelize_name) %>: InputValue<<%= swift_input_type(field.type, non_null: true) %>>
       <% end %>
 
       public init(
         <% input_fields = type.required_input_fields + type.optional_input_fields %>
         <% input_fields.each do |field| %>
-          <% default = field.type.non_null? ? "" : " = nil" %>
           <% seperator = field == input_fields.last ? "" : "," %>
-          <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type) %><%= default %><%= seperator %>
+          <% if field.type.non_null? %>
+            <%= escape_reserved_word(field.camelize_name) %>: <%= swift_input_type(field.type, non_null: true) %><%= seperator %>
+          <% else %>
+            <%= escape_reserved_word(field.camelize_name) %>: InputValue<<%= swift_input_type(field.type, non_null: true) %>> = .undefined<%= seperator %>
+          <% end %>
         <% end %>
       ) {
         <% type.input_fields.each do |field| %>
@@ -232,14 +238,19 @@ extension <%= schema_name %> {
 
       func serialize() -> String {
         var fields: [String] = []
-        <% type.input_fields.each do |field| %>
-          <% unless field.type.non_null? %>
+        <% type.required_input_fields.each do |field| %>
+          fields.append("<%= field.name %>:<%= generate_build_input_code(field.camelize_name, field.type.unwrap_non_null) %>")
+        <% end %>
+        <% type.optional_input_fields.each do |field| %>
+          switch <%= escape_reserved_word(field.camelize_name) %> {
+          case .defined(let <%= escape_reserved_word(field.camelize_name) %>):
             if let <%= escape_reserved_word(field.camelize_name) %> = <%= escape_reserved_word(field.camelize_name) %> {
-          <% end %>
               fields.append("<%= field.name %>:<%= generate_build_input_code(field.camelize_name, field.type.unwrap_non_null) %>")
-          <% unless field.type.non_null? %>
+            } else {
+              fields.append("<%= field.name %>:null")
             }
-          <% end %>
+          case .undefined: break
+          }
         <% end %>
         return "{\(fields.joined(separator: ","))}"
       }

--- a/support/Sources/GraphQL.swift
+++ b/support/Sources/GraphQL.swift
@@ -294,6 +294,21 @@ public struct SchemaViolationError: Error {
 	}
 }
 
+public enum InputValue<T> {
+	// Serialzeable value
+    case defined(T?)
+	// Not serializable
+    case undefined
+    
+    public init(orUndefined optional: Optional<T>)  {
+        if let value = optional {
+            self = .defined(value)
+        } else {
+            self = .undefined
+        }
+    }
+}
+
 extension GraphQL.Selection: Equatable {}
 public func ==(lhs: GraphQL.Selection, rhs: GraphQL.Selection) -> Bool {
 	return (lhs === rhs) || (lhs.field == rhs.field && lhs.alias == rhs.alias && lhs.args == rhs.args && lhs.subfields == rhs.subfields)

--- a/support/Sources/GraphQL.swift
+++ b/support/Sources/GraphQL.swift
@@ -294,15 +294,15 @@ public struct SchemaViolationError: Error {
 	}
 }
 
-public enum InputValue<T> {
+public enum Input<T> {
 	// Serialzeable value
-    case defined(T?)
+    case value(T?)
 	// Not serializable
     case undefined
     
     public init(orUndefined optional: Optional<T>)  {
         if let value = optional {
-            self = .defined(value)
+            self = .value(value)
         } else {
             self = .undefined
         }

--- a/support/Tests/GraphQLSupportTests/Generated/SetIntegerInput.swift
+++ b/support/Tests/GraphQLSupportTests/Generated/SetIntegerInput.swift
@@ -9,42 +9,26 @@ extension Generated {
 
 		open var value: Int32
 
-		open var ttl: Date? {
-			didSet {
-				ttlSeen = true
-			}
-		}
-		private var ttlSeen: Bool = false
+		open var ttl: InputValue<Date>
 
-		open var negate: Bool? {
-			didSet {
-				negateSeen = true
-			}
-		}
-		private var negateSeen: Bool = false
+		open var negate: InputValue<Bool>
 
 		public init(
 			key: String,
 
 			value: Int32,
 
-			ttl: Date?? = nil,
+			ttl: InputValue<Date> = .undefined,
 
-			negate: Bool?? = nil
+			negate: InputValue<Bool> = .undefined
 		) {
 			self.key = key
 
 			self.value = value
 
-			if let ttl = ttl {
-				self.ttlSeen = true
-				self.ttl = ttl
-			}
+			self.ttl = ttl
 
-			if let negate = negate {
-				self.negateSeen = true
-				self.negate = negate
-			}
+			self.negate = negate
 		}
 
 		func serialize() -> String {
@@ -54,20 +38,24 @@ extension Generated {
 
 			fields.append("value:\(value)")
 
-			if ttlSeen {
+			switch ttl {
+				case .defined(let ttl):
 				if let ttl = ttl {
 					fields.append("ttl:\(GraphQL.quoteString(input: "\(iso8601DateParser.string(from: ttl))"))")
 				} else {
 					fields.append("ttl:null")
 				}
+				case .undefined: break
 			}
 
-			if negateSeen {
+			switch negate {
+				case .defined(let negate):
 				if let negate = negate {
 					fields.append("negate:\(negate)")
 				} else {
 					fields.append("negate:null")
 				}
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/support/Tests/GraphQLSupportTests/Generated/SetIntegerInput.swift
+++ b/support/Tests/GraphQLSupportTests/Generated/SetIntegerInput.swift
@@ -9,18 +9,18 @@ extension Generated {
 
 		open var value: Int32
 
-		open var ttl: InputValue<Date>
+		open var ttl: Input<Date>
 
-		open var negate: InputValue<Bool>
+		open var negate: Input<Bool>
 
 		public init(
 			key: String,
 
 			value: Int32,
 
-			ttl: InputValue<Date> = .undefined,
+			ttl: Input<Date> = .undefined,
 
-			negate: InputValue<Bool> = .undefined
+			negate: Input<Bool> = .undefined
 		) {
 			self.key = key
 
@@ -39,7 +39,7 @@ extension Generated {
 			fields.append("value:\(value)")
 
 			switch ttl {
-				case .defined(let ttl):
+				case .value(let ttl):
 				if let ttl = ttl {
 					fields.append("ttl:\(GraphQL.quoteString(input: "\(iso8601DateParser.string(from: ttl))"))")
 				} else {
@@ -49,7 +49,7 @@ extension Generated {
 			}
 
 			switch negate {
-				case .defined(let negate):
+				case .value(let negate):
 				if let negate = negate {
 					fields.append("negate:\(negate)")
 				} else {

--- a/support/Tests/GraphQLSupportTests/IntegrationTests.swift
+++ b/support/Tests/GraphQLSupportTests/IntegrationTests.swift
@@ -62,16 +62,50 @@ class IntegrationTests: XCTestCase {
 
     func testInputObject() {
         let query = Generated.buildMutation { $0
-            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: true))
+            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: InputValue(orUndefined: true)))
         }
         let queryString = String(describing: query)
         XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42,negate:true})}")
     }
 
+    func testInputObjectExplicitUndefined() {
+        let query = Generated.buildMutation { $0
+            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: .undefined))
+        }
+        let queryString = String(describing: query)
+        XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42})}")
+    }
+
+    func testInputObjectOrUndefined() {
+        let query = Generated.buildMutation { $0
+            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: InputValue(orUndefined: nil)))
+        }
+        let queryString = String(describing: query)
+        XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42})}")
+    }
+
+    func testInputObjectExplictNullConstructor() {
+        let query = Generated.buildMutation { $0
+            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: .defined(nil)))
+        }
+        let queryString = String(describing: query)
+        XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42,negate:null})}")
+    }
+
+    func testInputObjectExplictNullSetLater() {
+        let input = Generated.SetIntegerInput(key: "answer", value: 42)
+        input.negate = .defined(nil)
+        let query = Generated.buildMutation { $0
+            .setInteger(input: input)
+        }
+        let queryString = String(describing: query)
+        XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42,negate:null})}")
+    }
+
     func testScalarInput() {
         let ttl = date(year: 2017, month: 1, day: 31, hour: 10, minute: 9, second: 48)
         let query = Generated.buildMutation { $0
-            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, ttl: ttl))
+            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, ttl: .defined(ttl)))
         }
         let queryString = String(describing: query)
         XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42,ttl:\"2017-01-31T10:09:48Z\"})}")

--- a/support/Tests/GraphQLSupportTests/IntegrationTests.swift
+++ b/support/Tests/GraphQLSupportTests/IntegrationTests.swift
@@ -62,7 +62,7 @@ class IntegrationTests: XCTestCase {
 
     func testInputObject() {
         let query = Generated.buildMutation { $0
-            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: InputValue(orUndefined: true)))
+            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: Input(orUndefined: true)))
         }
         let queryString = String(describing: query)
         XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42,negate:true})}")
@@ -78,7 +78,7 @@ class IntegrationTests: XCTestCase {
 
     func testInputObjectOrUndefined() {
         let query = Generated.buildMutation { $0
-            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: InputValue(orUndefined: nil)))
+            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: Input(orUndefined: nil)))
         }
         let queryString = String(describing: query)
         XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42})}")
@@ -86,7 +86,7 @@ class IntegrationTests: XCTestCase {
 
     func testInputObjectExplictNullConstructor() {
         let query = Generated.buildMutation { $0
-            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: .defined(nil)))
+            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, negate: .value(nil)))
         }
         let queryString = String(describing: query)
         XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42,negate:null})}")
@@ -94,7 +94,7 @@ class IntegrationTests: XCTestCase {
 
     func testInputObjectExplictNullSetLater() {
         let input = Generated.SetIntegerInput(key: "answer", value: 42)
-        input.negate = .defined(nil)
+        input.negate = .value(nil)
         let query = Generated.buildMutation { $0
             .setInteger(input: input)
         }
@@ -105,7 +105,7 @@ class IntegrationTests: XCTestCase {
     func testScalarInput() {
         let ttl = date(year: 2017, month: 1, day: 31, hour: 10, minute: 9, second: 48)
         let query = Generated.buildMutation { $0
-            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, ttl: .defined(ttl)))
+            .setInteger(input: Generated.SetIntegerInput(key: "answer", value: 42, ttl: .value(ttl)))
         }
         let queryString = String(describing: query)
         XCTAssertEqual(queryString, "mutation{set_integer(input:{key:\"answer\",value:42,ttl:\"2017-01-31T10:09:48Z\"})}")


### PR DESCRIPTION
# This PR
This is a competing PR with #12. This proposal takes out the explicit null logic in #14.
The aim of this PR is to allow you to set explicit `null` values on nullable properties on input types. 

* Makes required properties non optional
* Removes the old `#{propertyName}seen` observers triggered on `didSet`. 
* Adds the wrapper type `InputValue` to GraphQL.swift

New input types are in the form: 
```swift
class InputType2 {
	// not nullable
	var id: Int
	// not nullable
	var title: String
	// nullable
	var description: InputValue<String>
	
	init(id: Int, title: String, description: InputValue<String> = .undefined) {
		self.id = id
		self.title = title
		self.description = description
	}
	
	// The 
	var serialize: String {
		var string = "{ "
		string += "id: \(id), "
		string += "title: \(title), "
		switch description {
		case .some(let value):
			if let value = value {
				string += "description: \(value), "
			} else {
				string += "description: null, "
			}
		case .undefined: break
		}
		string += " }"
		return string
	}
}
```

## API Breakage
The new change causes some API breakage. 
```swift
// Before
convenience init(from product: Product) {
  self.init(
    id: product.id, // required
    title: product.title, // nullable
    description: product.description // nullable
  )
}

// After 
convenience init(from product: Product) {
  self.init(
    id: product.id, 
    title: InputValue(orUndefined: product.title),
    description: InputValue(orUndefined: product.description)
  )
}
```

Closes #12 