### PR TITLE
Commit generated code for tests to provide more information to reviewers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 /Gemfile.lock
 /pkg/
 /tmp/
-/support/Tests/GraphQLSupportTests/Generated.swift
-/support/Tests/GraphQLSupportTests/Generated/

--- a/support/Tests/GraphQLSupportTests/Generated.swift
+++ b/support/Tests/GraphQLSupportTests/Generated.swift
@@ -1,0 +1,15 @@
+// Generated from graphql_swift_gen gem
+
+open class Generated {
+	open static func buildQuery(_ subfields: (QueryRootQuery) -> Void) -> QueryRootQuery {
+		let root = QueryRootQuery()
+		subfields(root)
+		return root
+	}
+
+	open static func buildMutation(_ subfields: (MutationQuery) -> Void) -> MutationQuery {
+		let root = MutationQuery()
+		subfields(root)
+		return root
+	}
+}

--- a/support/Tests/GraphQLSupportTests/Generated/Entry.swift
+++ b/support/Tests/GraphQLSupportTests/Generated/Entry.swift
@@ -1,0 +1,152 @@
+// Generated from graphql_swift_gen gem
+import Foundation
+
+import GraphQLSupport
+
+public protocol Entry {
+	var typeName: String { get }
+
+	var key: String { get }
+
+	var ttl: Date? { get }
+
+	func childResponseObjectMap() -> [GraphQL.AbstractResponse]
+
+	func responseObject() -> GraphQL.AbstractResponse
+}
+
+extension Generated {
+	open class EntryQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Entry
+
+		@discardableResult
+		open func key(aliasSuffix: String? = nil) -> EntryQuery {
+			addField(field: "key", aliasSuffix: aliasSuffix)
+			return self
+		}
+
+		@discardableResult
+		open func ttl(aliasSuffix: String? = nil) -> EntryQuery {
+			addField(field: "ttl", aliasSuffix: aliasSuffix)
+			return self
+		}
+
+		override init() {
+			super.init()
+			addField(field: "__typename")
+		}
+
+		@discardableResult
+		open func onIntegerEntry(subfields: (IntegerEntryQuery) -> Void) -> EntryQuery {
+			let subquery = IntegerEntryQuery()
+			subfields(subquery)
+			addInlineFragment(on: "IntegerEntry", subfields: subquery)
+			return self
+		}
+
+		@discardableResult
+		open func onStringEntry(subfields: (StringEntryQuery) -> Void) -> EntryQuery {
+			let subquery = StringEntryQuery()
+			subfields(subquery)
+			addInlineFragment(on: "StringEntry", subfields: subquery)
+			return self
+		}
+	}
+
+	open class UnknownEntry: GraphQL.AbstractResponse, GraphQLObject, Entry {
+		public typealias Query = EntryQuery
+
+		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "key":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: UnknownEntry.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "ttl":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: UnknownEntry.self, field: fieldName, value: fieldValue)
+				}
+				return iso8601DateParser.date(from: value)!
+
+				default:
+				throw SchemaViolationError(type: UnknownEntry.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		open var typeName: String { return field(field: "__typename") as! String }
+
+		open static func create(fields: [String: Any]) throws -> Entry {
+			guard let typeName = fields["__typename"] as? String else {
+				throw SchemaViolationError(type: UnknownEntry.self, field: "__typename", value: fields["__typename"] ?? NSNull())
+			}
+			switch typeName {
+				case "IntegerEntry":
+				return try IntegerEntry.init(fields: fields)
+
+				case "StringEntry":
+				return try StringEntry.init(fields: fields)
+
+				default:
+				return try UnknownEntry.init(fields: fields)
+			}
+		}
+
+		open var key: String {
+			return internalGetKey()
+		}
+
+		func internalGetKey(aliasSuffix: String? = nil) -> String {
+			return field(field: "key", aliasSuffix: aliasSuffix) as! String
+		}
+
+		open var ttl: Date? {
+			return internalGetTtl()
+		}
+
+		func internalGetTtl(aliasSuffix: String? = nil) -> Date? {
+			return field(field: "ttl", aliasSuffix: aliasSuffix) as! Date?
+		}
+
+		override open func childObjectType(key: String) -> GraphQL.ChildObjectType {
+			switch(key) {
+				case "key":
+
+				return .scalar
+
+				case "ttl":
+
+				return .scalar
+
+				default:
+				return .scalar
+			}
+		}
+
+		override open func fetchChildObject(key: String) -> GraphQL.AbstractResponse? {
+			switch(key) {
+				default:
+				break
+			}
+			return nil
+		}
+
+		override open func fetchChildObjectList(key: String) -> [GraphQL.AbstractResponse] {
+			switch(key) {
+				default:
+				return []
+			}
+		}
+
+		open func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			return []
+		}
+
+		open func responseObject() -> GraphQL.AbstractResponse {
+			return self as GraphQL.AbstractResponse
+		}
+	}
+}

--- a/support/Tests/GraphQLSupportTests/Generated/EntryUnion.swift
+++ b/support/Tests/GraphQLSupportTests/Generated/EntryUnion.swift
@@ -1,0 +1,99 @@
+// Generated from graphql_swift_gen gem
+import Foundation
+
+import GraphQLSupport
+
+public protocol EntryUnion {
+	var typeName: String { get }
+
+	func childResponseObjectMap() -> [GraphQL.AbstractResponse]
+
+	func responseObject() -> GraphQL.AbstractResponse
+}
+
+extension Generated {
+	open class EntryUnionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = EntryUnion
+
+		override init() {
+			super.init()
+			addField(field: "__typename")
+		}
+
+		@discardableResult
+		open func onIntegerEntry(subfields: (IntegerEntryQuery) -> Void) -> EntryUnionQuery {
+			let subquery = IntegerEntryQuery()
+			subfields(subquery)
+			addInlineFragment(on: "IntegerEntry", subfields: subquery)
+			return self
+		}
+
+		@discardableResult
+		open func onStringEntry(subfields: (StringEntryQuery) -> Void) -> EntryUnionQuery {
+			let subquery = StringEntryQuery()
+			subfields(subquery)
+			addInlineFragment(on: "StringEntry", subfields: subquery)
+			return self
+		}
+	}
+
+	open class UnknownEntryUnion: GraphQL.AbstractResponse, GraphQLObject, EntryUnion {
+		public typealias Query = EntryUnionQuery
+
+		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				default:
+				throw SchemaViolationError(type: UnknownEntryUnion.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		open var typeName: String { return field(field: "__typename") as! String }
+
+		open static func create(fields: [String: Any]) throws -> EntryUnion {
+			guard let typeName = fields["__typename"] as? String else {
+				throw SchemaViolationError(type: UnknownEntryUnion.self, field: "__typename", value: fields["__typename"] ?? NSNull())
+			}
+			switch typeName {
+				case "IntegerEntry":
+				return try IntegerEntry.init(fields: fields)
+
+				case "StringEntry":
+				return try StringEntry.init(fields: fields)
+
+				default:
+				return try UnknownEntryUnion.init(fields: fields)
+			}
+		}
+
+		override open func childObjectType(key: String) -> GraphQL.ChildObjectType {
+			switch(key) {
+				default:
+				return .scalar
+			}
+		}
+
+		override open func fetchChildObject(key: String) -> GraphQL.AbstractResponse? {
+			switch(key) {
+				default:
+				break
+			}
+			return nil
+		}
+
+		override open func fetchChildObjectList(key: String) -> [GraphQL.AbstractResponse] {
+			switch(key) {
+				default:
+				return []
+			}
+		}
+
+		open func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			return []
+		}
+
+		open func responseObject() -> GraphQL.AbstractResponse {
+			return self as GraphQL.AbstractResponse
+		}
+	}
+}

--- a/support/Tests/GraphQLSupportTests/Generated/IntegerEntry.swift
+++ b/support/Tests/GraphQLSupportTests/Generated/IntegerEntry.swift
@@ -1,0 +1,127 @@
+// Generated from graphql_swift_gen gem
+import Foundation
+
+import GraphQLSupport
+
+extension Generated {
+	open class IntegerEntryQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = IntegerEntry
+
+		@discardableResult
+		open func key(aliasSuffix: String? = nil) -> IntegerEntryQuery {
+			addField(field: "key", aliasSuffix: aliasSuffix)
+			return self
+		}
+
+		@discardableResult
+		open func ttl(aliasSuffix: String? = nil) -> IntegerEntryQuery {
+			addField(field: "ttl", aliasSuffix: aliasSuffix)
+			return self
+		}
+
+		@discardableResult
+		open func value(aliasSuffix: String? = nil) -> IntegerEntryQuery {
+			addField(field: "value", aliasSuffix: aliasSuffix)
+			return self
+		}
+	}
+
+	open class IntegerEntry: GraphQL.AbstractResponse, GraphQLObject, Entry, EntryUnion {
+		public typealias Query = IntegerEntryQuery
+
+		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "key":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: IntegerEntry.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "ttl":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: IntegerEntry.self, field: fieldName, value: fieldValue)
+				}
+				return iso8601DateParser.date(from: value)!
+
+				case "value":
+				guard let value = value as? Int else {
+					throw SchemaViolationError(type: IntegerEntry.self, field: fieldName, value: fieldValue)
+				}
+				return Int32(value)
+
+				default:
+				throw SchemaViolationError(type: IntegerEntry.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		open var typeName: String { return "IntegerEntry" }
+
+		open var key: String {
+			return internalGetKey()
+		}
+
+		func internalGetKey(aliasSuffix: String? = nil) -> String {
+			return field(field: "key", aliasSuffix: aliasSuffix) as! String
+		}
+
+		open var ttl: Date? {
+			return internalGetTtl()
+		}
+
+		func internalGetTtl(aliasSuffix: String? = nil) -> Date? {
+			return field(field: "ttl", aliasSuffix: aliasSuffix) as! Date?
+		}
+
+		open var value: Int32 {
+			return internalGetValue()
+		}
+
+		func internalGetValue(aliasSuffix: String? = nil) -> Int32 {
+			return field(field: "value", aliasSuffix: aliasSuffix) as! Int32
+		}
+
+		override open func childObjectType(key: String) -> GraphQL.ChildObjectType {
+			switch(key) {
+				case "key":
+
+				return .scalar
+
+				case "ttl":
+
+				return .scalar
+
+				case "value":
+
+				return .scalar
+
+				default:
+				return .scalar
+			}
+		}
+
+		override open func fetchChildObject(key: String) -> GraphQL.AbstractResponse? {
+			switch(key) {
+				default:
+				break
+			}
+			return nil
+		}
+
+		override open func fetchChildObjectList(key: String) -> [GraphQL.AbstractResponse] {
+			switch(key) {
+				default:
+				return []
+			}
+		}
+
+		open func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			return []
+		}
+
+		open func responseObject() -> GraphQL.AbstractResponse {
+			return self as GraphQL.AbstractResponse
+		}
+	}
+}

--- a/support/Tests/GraphQLSupportTests/Generated/KeyType.swift
+++ b/support/Tests/GraphQLSupportTests/Generated/KeyType.swift
@@ -1,0 +1,17 @@
+// Generated from graphql_swift_gen gem
+import Foundation
+
+import GraphQLSupport
+
+extension Generated {
+	public enum KeyType: String {
+		case integer = "INTEGER"
+
+		@available(*, deprecated, message:"GraphQL null now used instead")
+		case notFound = "NOT_FOUND"
+
+		case string = "STRING"
+
+		case unknownValue = ""
+	}
+}

--- a/support/Tests/GraphQLSupportTests/Generated/Mutation.swift
+++ b/support/Tests/GraphQLSupportTests/Generated/Mutation.swift
@@ -1,0 +1,204 @@
+// Generated from graphql_swift_gen gem
+import Foundation
+
+import GraphQLSupport
+
+extension Generated {
+	open class MutationQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Mutation
+
+		open override var description: String {
+			return "mutation" + super.description
+		}
+
+		@available(*, deprecated, message:"Ambiguous, use set_string instead")
+		@discardableResult
+		open func `set`(aliasSuffix: String? = nil, key: String) -> MutationQuery {
+			var args: [String] = []
+
+			args.append("key:\(GraphQL.quoteString(input: key))")
+
+			let argsString = "(\(args.joined(separator: ",")))"
+
+			addField(field: "set", aliasSuffix: aliasSuffix, args: argsString)
+			return self
+		}
+
+		@discardableResult
+		open func setInteger(aliasSuffix: String? = nil, input: SetIntegerInput) -> MutationQuery {
+			var args: [String] = []
+
+			args.append("input:\(input.serialize())")
+
+			let argsString = "(\(args.joined(separator: ",")))"
+
+			addField(field: "set_integer", aliasSuffix: aliasSuffix, args: argsString)
+			return self
+		}
+
+		@discardableResult
+		open func setString(aliasSuffix: String? = nil, key: String, value: String) -> MutationQuery {
+			var args: [String] = []
+
+			args.append("key:\(GraphQL.quoteString(input: key))")
+
+			args.append("value:\(GraphQL.quoteString(input: value))")
+
+			let argsString = "(\(args.joined(separator: ",")))"
+
+			addField(field: "set_string", aliasSuffix: aliasSuffix, args: argsString)
+			return self
+		}
+
+		@discardableResult
+		open func setStringWithDefault(aliasSuffix: String? = nil, key: String, value: String? = nil) -> MutationQuery {
+			var args: [String] = []
+
+			args.append("key:\(GraphQL.quoteString(input: key))")
+
+			if let value = value {
+				args.append("value:\(GraphQL.quoteString(input: value))")
+			}
+
+			let argsString: String? = args.isEmpty ? nil : "(\(args.joined(separator: ",")))"
+
+			addField(field: "set_string_with_default", aliasSuffix: aliasSuffix, args: argsString)
+			return self
+		}
+	}
+
+	open class Mutation: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = MutationQuery
+
+		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "set":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "set_integer":
+				guard let value = value as? Bool else {
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "set_string":
+				guard let value = value as? Bool else {
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "set_string_with_default":
+				guard let value = value as? Bool else {
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				default:
+				throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		open var typeName: String { return "Mutation" }
+
+		@available(*, deprecated, message:"Ambiguous, use set_string instead")
+		open var `set`: String? {
+			return internalGetSet()
+		}
+
+		@available(*, deprecated, message:"Ambiguous, use set_string instead")
+		open func aliasedSet(aliasSuffix: String) -> String? {
+			return internalGetSet(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetSet(aliasSuffix: String? = nil) -> String? {
+			return field(field: "set", aliasSuffix: aliasSuffix) as! String?
+		}
+
+		open var setInteger: Bool {
+			return internalGetSetInteger()
+		}
+
+		open func aliasedSetInteger(aliasSuffix: String) -> Bool {
+			return internalGetSetInteger(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetSetInteger(aliasSuffix: String? = nil) -> Bool {
+			return field(field: "set_integer", aliasSuffix: aliasSuffix) as! Bool
+		}
+
+		open var setString: Bool {
+			return internalGetSetString()
+		}
+
+		open func aliasedSetString(aliasSuffix: String) -> Bool {
+			return internalGetSetString(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetSetString(aliasSuffix: String? = nil) -> Bool {
+			return field(field: "set_string", aliasSuffix: aliasSuffix) as! Bool
+		}
+
+		open var setStringWithDefault: Bool {
+			return internalGetSetStringWithDefault()
+		}
+
+		open func aliasedSetStringWithDefault(aliasSuffix: String) -> Bool {
+			return internalGetSetStringWithDefault(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetSetStringWithDefault(aliasSuffix: String? = nil) -> Bool {
+			return field(field: "set_string_with_default", aliasSuffix: aliasSuffix) as! Bool
+		}
+
+		override open func childObjectType(key: String) -> GraphQL.ChildObjectType {
+			switch(key) {
+				case "set":
+
+				return .scalar
+
+				case "set_integer":
+
+				return .scalar
+
+				case "set_string":
+
+				return .scalar
+
+				case "set_string_with_default":
+
+				return .scalar
+
+				default:
+				return .scalar
+			}
+		}
+
+		override open func fetchChildObject(key: String) -> GraphQL.AbstractResponse? {
+			switch(key) {
+				default:
+				break
+			}
+			return nil
+		}
+
+		override open func fetchChildObjectList(key: String) -> [GraphQL.AbstractResponse] {
+			switch(key) {
+				default:
+				return []
+			}
+		}
+
+		open func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			return []
+		}
+
+		open func responseObject() -> GraphQL.AbstractResponse {
+			return self as GraphQL.AbstractResponse
+		}
+	}
+}

--- a/support/Tests/GraphQLSupportTests/Generated/QueryRoot.swift
+++ b/support/Tests/GraphQLSupportTests/Generated/QueryRoot.swift
@@ -1,0 +1,483 @@
+// Generated from graphql_swift_gen gem
+import Foundation
+
+import GraphQLSupport
+
+extension Generated {
+	open class QueryRootQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = QueryRoot
+
+		@discardableResult
+		open func entries(aliasSuffix: String? = nil, first: Int32, after: String? = nil, _ subfields: (EntryQuery) -> Void) -> QueryRootQuery {
+			var args: [String] = []
+
+			args.append("first:\(first)")
+
+			if let after = after {
+				args.append("after:\(GraphQL.quoteString(input: after))")
+			}
+
+			let argsString: String? = args.isEmpty ? nil : "(\(args.joined(separator: ",")))"
+
+			let subquery = EntryQuery()
+			subfields(subquery)
+
+			addField(field: "entries", aliasSuffix: aliasSuffix, args: argsString, subfields: subquery)
+			return self
+		}
+
+		@discardableResult
+		open func entry(aliasSuffix: String? = nil, key: String, _ subfields: (EntryQuery) -> Void) -> QueryRootQuery {
+			var args: [String] = []
+
+			args.append("key:\(GraphQL.quoteString(input: key))")
+
+			let argsString = "(\(args.joined(separator: ",")))"
+
+			let subquery = EntryQuery()
+			subfields(subquery)
+
+			addField(field: "entry", aliasSuffix: aliasSuffix, args: argsString, subfields: subquery)
+			return self
+		}
+
+		@discardableResult
+		open func entryUnion(aliasSuffix: String? = nil, key: String, _ subfields: (EntryUnionQuery) -> Void) -> QueryRootQuery {
+			var args: [String] = []
+
+			args.append("key:\(GraphQL.quoteString(input: key))")
+
+			let argsString = "(\(args.joined(separator: ",")))"
+
+			let subquery = EntryUnionQuery()
+			subfields(subquery)
+
+			addField(field: "entry_union", aliasSuffix: aliasSuffix, args: argsString, subfields: subquery)
+			return self
+		}
+
+		@available(*, deprecated, message:"Ambiguous, use string instead")
+		@discardableResult
+		open func `get`(aliasSuffix: String? = nil, key: String) -> QueryRootQuery {
+			var args: [String] = []
+
+			args.append("key:\(GraphQL.quoteString(input: key))")
+
+			let argsString = "(\(args.joined(separator: ",")))"
+
+			addField(field: "get", aliasSuffix: aliasSuffix, args: argsString)
+			return self
+		}
+
+		@discardableResult
+		open func integer(aliasSuffix: String? = nil, key: String) -> QueryRootQuery {
+			var args: [String] = []
+
+			args.append("key:\(GraphQL.quoteString(input: key))")
+
+			let argsString = "(\(args.joined(separator: ",")))"
+
+			addField(field: "integer", aliasSuffix: aliasSuffix, args: argsString)
+			return self
+		}
+
+		@discardableResult
+		open func keys(aliasSuffix: String? = nil, first: Int32, after: String? = nil, type: KeyType? = nil) -> QueryRootQuery {
+			var args: [String] = []
+
+			args.append("first:\(first)")
+
+			if let after = after {
+				args.append("after:\(GraphQL.quoteString(input: after))")
+			}
+
+			if let type = type {
+				args.append("type:\(type.rawValue)")
+			}
+
+			let argsString: String? = args.isEmpty ? nil : "(\(args.joined(separator: ",")))"
+
+			addField(field: "keys", aliasSuffix: aliasSuffix, args: argsString)
+			return self
+		}
+
+		@discardableResult
+		open func mget(aliasSuffix: String? = nil, keys: [String]) -> QueryRootQuery {
+			var args: [String] = []
+
+			args.append("keys:[\(keys.map{ "\(GraphQL.quoteString(input: $0))" }.joined(separator: ","))]")
+
+			let argsString = "(\(args.joined(separator: ",")))"
+
+			addField(field: "mget", aliasSuffix: aliasSuffix, args: argsString)
+			return self
+		}
+
+		@discardableResult
+		open func string(aliasSuffix: String? = nil, key: String) -> QueryRootQuery {
+			var args: [String] = []
+
+			args.append("key:\(GraphQL.quoteString(input: key))")
+
+			let argsString = "(\(args.joined(separator: ",")))"
+
+			addField(field: "string", aliasSuffix: aliasSuffix, args: argsString)
+			return self
+		}
+
+		@discardableResult
+		open func ttl(aliasSuffix: String? = nil, key: String) -> QueryRootQuery {
+			var args: [String] = []
+
+			args.append("key:\(GraphQL.quoteString(input: key))")
+
+			let argsString = "(\(args.joined(separator: ",")))"
+
+			addField(field: "ttl", aliasSuffix: aliasSuffix, args: argsString)
+			return self
+		}
+
+		@discardableResult
+		open func type(aliasSuffix: String? = nil, key: String) -> QueryRootQuery {
+			var args: [String] = []
+
+			args.append("key:\(GraphQL.quoteString(input: key))")
+
+			let argsString = "(\(args.joined(separator: ",")))"
+
+			addField(field: "type", aliasSuffix: aliasSuffix, args: argsString)
+			return self
+		}
+
+		@discardableResult
+		open func version(aliasSuffix: String? = nil) -> QueryRootQuery {
+			addField(field: "version", aliasSuffix: aliasSuffix)
+			return self
+		}
+	}
+
+	open class QueryRoot: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = QueryRootQuery
+
+		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "entries":
+				guard let value = value as? [[String: Any]] else {
+					throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+				}
+				return try value.map { return try UnknownEntry.create(fields: $0) }
+
+				case "entry":
+				if value is NSNull { return nil }
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+				}
+				return try UnknownEntry.create(fields: value)
+
+				case "entry_union":
+				if value is NSNull { return nil }
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+				}
+				return try UnknownEntryUnion.create(fields: value)
+
+				case "get":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "integer":
+				if value is NSNull { return nil }
+				guard let value = value as? Int else {
+					throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+				}
+				return Int32(value)
+
+				case "keys":
+				guard let value = value as? [String] else {
+					throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+				}
+				return value.map { return $0 }
+
+				case "mget":
+				guard let value = value as? [Any] else {
+					throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+				}
+				return try value.map { if $0 is NSNull { return nil }
+				guard let value = $0 as? String else {
+					throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+				}
+				return value } as [Any?]
+
+				case "string":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "ttl":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+				}
+				return iso8601DateParser.date(from: value)!
+
+				case "type":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+				}
+				return KeyType(rawValue: value) ?? .unknownValue
+
+				case "version":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				default:
+				throw SchemaViolationError(type: QueryRoot.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		open var typeName: String { return "QueryRoot" }
+
+		open var entries: [Entry] {
+			return internalGetEntries()
+		}
+
+		open func aliasedEntries(aliasSuffix: String) -> [Entry] {
+			return internalGetEntries(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetEntries(aliasSuffix: String? = nil) -> [Entry] {
+			return field(field: "entries", aliasSuffix: aliasSuffix) as! [Entry]
+		}
+
+		open var entry: Entry? {
+			return internalGetEntry()
+		}
+
+		open func aliasedEntry(aliasSuffix: String) -> Entry? {
+			return internalGetEntry(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetEntry(aliasSuffix: String? = nil) -> Entry? {
+			return field(field: "entry", aliasSuffix: aliasSuffix) as! Entry?
+		}
+
+		open var entryUnion: EntryUnion? {
+			return internalGetEntryUnion()
+		}
+
+		open func aliasedEntryUnion(aliasSuffix: String) -> EntryUnion? {
+			return internalGetEntryUnion(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetEntryUnion(aliasSuffix: String? = nil) -> EntryUnion? {
+			return field(field: "entry_union", aliasSuffix: aliasSuffix) as! EntryUnion?
+		}
+
+		@available(*, deprecated, message:"Ambiguous, use string instead")
+		open var `get`: String? {
+			return internalGetGet()
+		}
+
+		@available(*, deprecated, message:"Ambiguous, use string instead")
+		open func aliasedGet(aliasSuffix: String) -> String? {
+			return internalGetGet(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetGet(aliasSuffix: String? = nil) -> String? {
+			return field(field: "get", aliasSuffix: aliasSuffix) as! String?
+		}
+
+		open var integer: Int32? {
+			return internalGetInteger()
+		}
+
+		open func aliasedInteger(aliasSuffix: String) -> Int32? {
+			return internalGetInteger(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetInteger(aliasSuffix: String? = nil) -> Int32? {
+			return field(field: "integer", aliasSuffix: aliasSuffix) as! Int32?
+		}
+
+		open var keys: [String] {
+			return internalGetKeys()
+		}
+
+		open func aliasedKeys(aliasSuffix: String) -> [String] {
+			return internalGetKeys(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetKeys(aliasSuffix: String? = nil) -> [String] {
+			return field(field: "keys", aliasSuffix: aliasSuffix) as! [String]
+		}
+
+		open var mget: [String?] {
+			return internalGetMget()
+		}
+
+		open func aliasedMget(aliasSuffix: String) -> [String?] {
+			return internalGetMget(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetMget(aliasSuffix: String? = nil) -> [String?] {
+			return field(field: "mget", aliasSuffix: aliasSuffix) as! [String?]
+		}
+
+		open var string: String? {
+			return internalGetString()
+		}
+
+		open func aliasedString(aliasSuffix: String) -> String? {
+			return internalGetString(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetString(aliasSuffix: String? = nil) -> String? {
+			return field(field: "string", aliasSuffix: aliasSuffix) as! String?
+		}
+
+		open var ttl: Date? {
+			return internalGetTtl()
+		}
+
+		open func aliasedTtl(aliasSuffix: String) -> Date? {
+			return internalGetTtl(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetTtl(aliasSuffix: String? = nil) -> Date? {
+			return field(field: "ttl", aliasSuffix: aliasSuffix) as! Date?
+		}
+
+		open var type: Generated.KeyType? {
+			return internalGetType()
+		}
+
+		open func aliasedType(aliasSuffix: String) -> Generated.KeyType? {
+			return internalGetType(aliasSuffix: aliasSuffix)
+		}
+
+		func internalGetType(aliasSuffix: String? = nil) -> Generated.KeyType? {
+			return field(field: "type", aliasSuffix: aliasSuffix) as! Generated.KeyType?
+		}
+
+		open var version: String? {
+			return internalGetVersion()
+		}
+
+		func internalGetVersion(aliasSuffix: String? = nil) -> String? {
+			return field(field: "version", aliasSuffix: aliasSuffix) as! String?
+		}
+
+		override open func childObjectType(key: String) -> GraphQL.ChildObjectType {
+			switch(key) {
+				case "entries":
+
+				return .objectList
+
+				case "entry":
+
+				return .object
+
+				case "entry_union":
+
+				return .scalar
+
+				case "get":
+
+				return .scalar
+
+				case "integer":
+
+				return .scalar
+
+				case "keys":
+
+				return .scalarList
+
+				case "mget":
+
+				return .scalarList
+
+				case "string":
+
+				return .scalar
+
+				case "ttl":
+
+				return .scalar
+
+				case "type":
+
+				return .scalar
+
+				case "version":
+
+				return .scalar
+
+				default:
+				return .scalar
+			}
+		}
+
+		override open func fetchChildObject(key: String) -> GraphQL.AbstractResponse? {
+			switch(key) {
+				case "entry":
+				return internalGetEntry()?.responseObject()
+
+				default:
+				break
+			}
+			return nil
+		}
+
+		override open func fetchChildObjectList(key: String) -> [GraphQL.AbstractResponse] {
+			switch(key) {
+				default:
+				return []
+			}
+		}
+
+		open func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			var response: [GraphQL.AbstractResponse] = []
+			objectMap.keys.forEach({
+				key in
+				switch(key) {
+					case "entries":
+					internalGetEntries().forEach {
+						response.append($0 as! GraphQL.AbstractResponse)
+						response.append(contentsOf: $0.childResponseObjectMap())
+					}
+
+					case "entry":
+					if let value = internalGetEntry() {
+						response.append(value as! GraphQL.AbstractResponse)
+						response.append(contentsOf: value.childResponseObjectMap())
+					}
+
+					case "entry_union":
+					if let value = internalGetEntryUnion() {
+						response.append(value as! GraphQL.AbstractResponse)
+						response.append(contentsOf: value.childResponseObjectMap())
+					}
+
+					default:
+					break
+				}
+			})
+			return response
+		}
+
+		open func responseObject() -> GraphQL.AbstractResponse {
+			return self as GraphQL.AbstractResponse
+		}
+	}
+}

--- a/support/Tests/GraphQLSupportTests/Generated/SetIntegerInput.swift
+++ b/support/Tests/GraphQLSupportTests/Generated/SetIntegerInput.swift
@@ -1,0 +1,76 @@
+// Generated from graphql_swift_gen gem
+import Foundation
+
+import GraphQLSupport
+
+extension Generated {
+	open class SetIntegerInput {
+		open var key: String
+
+		open var value: Int32
+
+		open var ttl: Date? {
+			didSet {
+				ttlSeen = true
+			}
+		}
+		private var ttlSeen: Bool = false
+
+		open var negate: Bool? {
+			didSet {
+				negateSeen = true
+			}
+		}
+		private var negateSeen: Bool = false
+
+		public init(
+			key: String,
+
+			value: Int32,
+
+			ttl: Date?? = nil,
+
+			negate: Bool?? = nil
+		) {
+			self.key = key
+
+			self.value = value
+
+			if let ttl = ttl {
+				self.ttlSeen = true
+				self.ttl = ttl
+			}
+
+			if let negate = negate {
+				self.negateSeen = true
+				self.negate = negate
+			}
+		}
+
+		func serialize() -> String {
+			var fields: [String] = []
+
+			fields.append("key:\(GraphQL.quoteString(input: key))")
+
+			fields.append("value:\(value)")
+
+			if ttlSeen {
+				if let ttl = ttl {
+					fields.append("ttl:\(GraphQL.quoteString(input: "\(iso8601DateParser.string(from: ttl))"))")
+				} else {
+					fields.append("ttl:null")
+				}
+			}
+
+			if negateSeen {
+				if let negate = negate {
+					fields.append("negate:\(negate)")
+				} else {
+					fields.append("negate:null")
+				}
+			}
+
+			return "{\(fields.joined(separator: ","))}"
+		}
+	}
+}

--- a/support/Tests/GraphQLSupportTests/Generated/StringEntry.swift
+++ b/support/Tests/GraphQLSupportTests/Generated/StringEntry.swift
@@ -1,0 +1,127 @@
+// Generated from graphql_swift_gen gem
+import Foundation
+
+import GraphQLSupport
+
+extension Generated {
+	open class StringEntryQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = StringEntry
+
+		@discardableResult
+		open func key(aliasSuffix: String? = nil) -> StringEntryQuery {
+			addField(field: "key", aliasSuffix: aliasSuffix)
+			return self
+		}
+
+		@discardableResult
+		open func ttl(aliasSuffix: String? = nil) -> StringEntryQuery {
+			addField(field: "ttl", aliasSuffix: aliasSuffix)
+			return self
+		}
+
+		@discardableResult
+		open func value(aliasSuffix: String? = nil) -> StringEntryQuery {
+			addField(field: "value", aliasSuffix: aliasSuffix)
+			return self
+		}
+	}
+
+	open class StringEntry: GraphQL.AbstractResponse, GraphQLObject, Entry, EntryUnion {
+		public typealias Query = StringEntryQuery
+
+		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "key":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: StringEntry.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "ttl":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: StringEntry.self, field: fieldName, value: fieldValue)
+				}
+				return iso8601DateParser.date(from: value)!
+
+				case "value":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: StringEntry.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				default:
+				throw SchemaViolationError(type: StringEntry.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		open var typeName: String { return "StringEntry" }
+
+		open var key: String {
+			return internalGetKey()
+		}
+
+		func internalGetKey(aliasSuffix: String? = nil) -> String {
+			return field(field: "key", aliasSuffix: aliasSuffix) as! String
+		}
+
+		open var ttl: Date? {
+			return internalGetTtl()
+		}
+
+		func internalGetTtl(aliasSuffix: String? = nil) -> Date? {
+			return field(field: "ttl", aliasSuffix: aliasSuffix) as! Date?
+		}
+
+		open var value: String {
+			return internalGetValue()
+		}
+
+		func internalGetValue(aliasSuffix: String? = nil) -> String {
+			return field(field: "value", aliasSuffix: aliasSuffix) as! String
+		}
+
+		override open func childObjectType(key: String) -> GraphQL.ChildObjectType {
+			switch(key) {
+				case "key":
+
+				return .scalar
+
+				case "ttl":
+
+				return .scalar
+
+				case "value":
+
+				return .scalar
+
+				default:
+				return .scalar
+			}
+		}
+
+		override open func fetchChildObject(key: String) -> GraphQL.AbstractResponse? {
+			switch(key) {
+				default:
+				break
+			}
+			return nil
+		}
+
+		override open func fetchChildObjectList(key: String) -> [GraphQL.AbstractResponse] {
+			switch(key) {
+				default:
+				return []
+			}
+		}
+
+		open func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			return []
+		}
+
+		open func responseObject() -> GraphQL.AbstractResponse {
+			return self as GraphQL.AbstractResponse
+		}
+	}
+}


### PR DESCRIPTION
Re: https://github.com/Shopify/graphql_swift_gen/pull/12#issuecomment-327929502

## Problem

It is harder to see what effect changes to the generator has without seeing an example of what is generated.

## Solution

We generate code as part of the test suite which we can check in to git to see a diff of changes to those files.  This will make it easier to see what effect changes to the generator will have.