### PR TITLE
lower versions of ruby don't have mkdir

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-
+ruby '~> 2.3.0'
 gemspec


### PR DESCRIPTION

/Users/johndpope/.rvm/gems/ruby-2.1.1/gems/graphql_swift_gen-0.1.0/codegen/lib/graphql_swift_gen.rb:21:in `mkdir': No such file or directory @ dir_s_mkdir - /Users/johndpope/Documents/gitWorkspace/graphql_swift_gen/BAM/Source/BAMSchema (Errno::ENOENT)
	from /Users/johndpope/.rvm/gems/ruby-2.1.1/gems/graphql_swift_gen-0.1.0/codegen/lib/graphql_swift_gen.rb:21:in `save'
	from test.rb:10:in `<main>'