### PR TITLE
Fix swift 4 warning

### DIFF
--- a/support/Sources/GraphQL.swift
+++ b/support/Sources/GraphQL.swift
@@ -187,7 +187,7 @@ public class GraphQL {
 		func fieldName(from key: String) -> String {
 			if let range = key.range(of: AbstractQuery.aliasSuffixSeparator) {
 				if key.distance(from: key.startIndex, to: range.lowerBound) > 0 {
-					return key.substring(to: range.lowerBound)
+					return String(key[..<range.lowerBound])
 				}
 			}
 			return key


### PR DESCRIPTION
replace deprecated substring with range to fix compile warning.