### PR TITLE
Add Linguist override to map `erb` files to be Ruby instead of HTML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.swift.erb linguist-language=Ruby


### PR DESCRIPTION
This is really just cosmetic for the repo.

This change overrides [`github/linguist`](https://github.com/github/linguist) to view the `*.swift.erb` files as Ruby instead of HTML.

Currently: 
<img width="984" alt="screen shot 2018-02-13 at 9 30 54 am" src="https://user-images.githubusercontent.com/11095731/36154969-1139fd44-10a1-11e8-8766-61f8d7c4ba14.png">

After Change:
<img width="984" alt="screen shot 2018-02-13 at 9 31 12 am" src="https://user-images.githubusercontent.com/11095731/36154979-19ae540c-10a1-11e8-9c6a-91b8cc6a8e3f.png">

CC: @dylanahsmith 