### PR TITLE
Replace git ls-files in gemspec with something equivalent

### DIFF
--- a/graphql_swift_gen.gemspec
+++ b/graphql_swift_gen.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/Shopify/graphql_swift_gen"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z codegen/lib LICENSE.txt README.md`.split("\x0")
+  spec.files         = Dir.glob("codegen/lib/**/*") + %w(LICENSE.txt README.md)
   spec.require_paths = ["codegen/lib"]
 
   spec.required_ruby_version = ">= 2.1.0"


### PR DESCRIPTION
Attempt to address https://github.com/Shopify/graphql_swift_gen/issues/28.

I'm investigating why Shopify Point of Sale iOS is [failing to build](https://buildkite.com/shopify/ios-mobile-shopify-pos/builds/886#001ee969-6cd5-4fd6-b915-d6e0f7a73a77/227-228) when the `.git` (2.5 GB) directory is not copied to the CI container. Ideally, all our projects should build and pass tests without relying on `.git` to be available. 

It seems to be related to this gem that is included in the Gemfile of the iOS monorepo.

- remove .git
- `bundle` in Shopify/ios: `fatal: Not a git repository (or any of the parent directories): .git`

With this proposed gemspec change:
- remove .git
- `bundle` passes without errors

This is allows us to optimize our builds with either shallow clones or no `.git` directory at all being copied into to the Anka container (https://github.com/Shopify/shopify-build/pull/832)